### PR TITLE
Refactor how JWTs are generated and used in rt sdk

### DIFF
--- a/sdk/rt/README.md
+++ b/sdk/rt/README.md
@@ -4,7 +4,7 @@ Async Python client for the Speechmatics Real-Time API.
 
 ## Features
 
-- **Async-first design** with synchronous wrappers for compatibility
+- **Async-first design** with simpler interface
 - **Comprehensive error handling** with detailed error messages
 - **Type hints throughout** for excellent IDE support and code safety
 - **Environment variable support** for secure credential management
@@ -40,9 +40,28 @@ async def main():
 asyncio.run(main())
 ```
 
+## JWT Authentication
+
+For enhanced security, use temporary JWT tokens instead of static API keys.
+JWTs are short-lived (60 seconds by default).
+
+```python
+from speechmatics.rt import AsyncClient, JWTAuth
+
+# Create JWT auth (requires: pip install 'speechmatics-rt[jwt]')
+auth = JWTAuth("your-api-key", ttl=60)
+
+async with AsyncClient(auth=auth) as client:
+    pass
+```
+
+Ideal for browser applications or when minimizing API key exposure.
+See the [authentication documentation](https://docs.speechmatics.com/introduction/authentication) for more details.
+
 ## Logging
 
-The client supports logging with job id tracing for debugging. To increase logging verbosity, set `DEBUG` level in your example code:
+The client supports logging with job id tracing for debugging.
+To increase logging verbosity, set `DEBUG` level in your example code:
 
 ```python
 import logging

--- a/sdk/rt/speechmatics/rt/__init__.py
+++ b/sdk/rt/speechmatics/rt/__init__.py
@@ -1,6 +1,9 @@
 __version__ = "0.0.0"
 
 from ._async_client import AsyncClient
+from ._auth import AuthBase
+from ._auth import JWTAuth
+from ._auth import StaticKeyAuth
 from ._events import EventEmitter
 from ._exceptions import AudioError
 from ._exceptions import AuthenticationError
@@ -26,6 +29,9 @@ from ._models import TranslationConfig
 
 __all__ = [
     "AsyncClient",
+    "AuthBase",
+    "JWTAuth",
+    "StaticKeyAuth",
     "EventEmitter",
     "AudioFormat",
     "AudioEventsConfig",

--- a/sdk/rt/speechmatics/rt/_auth.py
+++ b/sdk/rt/speechmatics/rt/_auth.py
@@ -1,0 +1,152 @@
+import abc
+import os
+from typing import Literal
+from typing import Optional
+
+from ._exceptions import AuthenticationError
+
+
+class AuthBase(abc.ABC):
+    """
+    Abstract base class for authentication methods.
+    """
+
+    BASE_URL = "https://mp.speechmatics.com"
+
+    @abc.abstractmethod
+    async def get_auth_headers(self) -> dict[str, str]:
+        """
+        Get authentication headers asynchronously.
+
+        Returns:
+            Dictionary of headers to include in the request.
+        """
+        raise NotImplementedError
+
+
+class StaticKeyAuth(AuthBase):
+    """
+    Authentication using a static API key.
+
+    This is the traditional authentication method where the same
+    API key is used for all requests.
+
+    Args:
+        api_key: The Speechmatics API key.
+
+    Examples:
+        >>> auth = StaticKeyAuth("your-api-key")
+        >>> headers = await auth.get_auth_headers()
+        >>> print(headers)
+        {'Authorization': 'Bearer your-api-key'}
+    """
+
+    def __init__(self, api_key: Optional[str] = None):
+        self._api_key = api_key or os.environ.get("SPEECHMATICS_API_KEY")
+
+        if not self._api_key:
+            raise ValueError("API key required: provide api_key or set SPEECHMATICS_API_KEY")
+
+    async def get_auth_headers(self) -> dict[str, str]:
+        return {"Authorization": f"Bearer {self._api_key}"}
+
+
+class JWTAuth(AuthBase):
+    """
+    Authentication using temporary JWT tokens.
+
+    Generates short-lived JWTs for enhanced security.
+
+    Args:
+        api_key: The main Speechmatics API key used to generate JWTs.
+        ttl: Time-to-live for tokens between 60 and 86400 seconds.
+            For security reasons, we suggest using the shortest TTL possible.
+        region: Self-Service customers are restricted to "eu".
+            Enterprise customers can use this to specify which region the temporary key should be enabled in.
+        client_ref: Optional client reference for JWT token.
+            This parameter must be used if the temporary keys are exposed to the end-user's client
+            to prevent a user from accessing the data of a different user.
+        mp_url: Optional management platform URL override.
+        request_id: Optional request ID for debugging purposes.
+
+    Examples:
+        >>> auth = JWTAuth("your-api-key")
+        >>> headers = await auth.get_auth_headers()
+        >>> print(headers)
+        {'Authorization': 'Bearer eyJhbGciOiJSUzI1NiIs...'}
+    """
+
+    def __init__(
+        self,
+        api_key: Optional[str] = None,
+        *,
+        ttl: int = 60,
+        region: Literal["eu", "usa"] = "eu",
+        client_ref: Optional[str] = None,
+        mp_url: Optional[str] = None,
+        request_id: Optional[str] = None,
+    ):
+        self._api_key = api_key or os.environ.get("SPEECHMATICS_API_KEY")
+        self._ttl = ttl
+        self._region = region
+        self._client_ref = client_ref
+        self._request_id = request_id
+        self._mp_url = mp_url or os.environ.get("SM_MANAGEMENT_PLATFORM_URL", self.BASE_URL)
+
+        if not self._api_key:
+            raise ValueError(
+                "API key required: please provide api_key or set SPEECHMATICS_API_KEY environment variable"
+            )
+
+        if not 60 <= self._ttl <= 86_400:
+            raise ValueError("ttl must be between 60 and 86400 seconds")
+
+    async def get_auth_headers(self) -> dict[str, str]:
+        """Get JWT auth headers."""
+
+        jwt = await self._generate_token()
+        return {"Authorization": f"Bearer {jwt}"}
+
+    async def _generate_token(self) -> str:
+        try:
+            import aiohttp
+        except ImportError:
+            raise ImportError(
+                "aiohttp is required for JWT authentication. Please install it with `pip install 'speechmatics-rt[jwt]'`"
+            )
+
+        endpoint = f"{self._mp_url}/v1/api_keys"
+        params = {"type": "rt"}
+        payload = {"ttl": self._ttl, "region": str(self._region)}
+
+        if self._client_ref:
+            payload["client_ref"] = self._client_ref
+
+        headers = {
+            "Authorization": f"Bearer {self._api_key}",
+            "Content-Type": "application/json",
+        }
+
+        if self._request_id:
+            headers["X-Request-Id"] = self._request_id
+
+        try:
+            async with aiohttp.ClientSession() as session:
+                async with session.post(
+                    endpoint,
+                    params=params,
+                    json=payload,
+                    headers=headers,
+                    timeout=aiohttp.ClientTimeout(total=10),
+                ) as response:
+                    if response.status != 201:
+                        text = await response.text()
+                        raise AuthenticationError(f"Failed to generate JWT: HTTP {response.status}: {text}")
+
+                    data = await response.json()
+                    return str(data["key_value"])
+
+        except aiohttp.ClientError as e:
+            raise AuthenticationError(f"Network error generating JWT: {e}")
+        except Exception as e:
+            raise AuthenticationError(f"Unexpected error generating JWT: {e}")

--- a/sdk/rt/speechmatics/rt/_helpers.py
+++ b/sdk/rt/speechmatics/rt/_helpers.py
@@ -7,7 +7,6 @@ from __future__ import annotations
 import asyncio
 import importlib.metadata
 import inspect
-import os
 from collections.abc import AsyncGenerator
 from typing import Any
 from typing import BinaryIO
@@ -52,29 +51,12 @@ async def read_audio_chunks(stream: Union[BinaryIO, Any], chunk_size: int) -> As
 
 
 def get_version() -> str:
-    """
-    Get SDK version from package metadata or __init__.py file.
-
-    Returns:
-        Version string
-    """
     try:
         return importlib.metadata.version("speechmatics-rt")
     except importlib.metadata.PackageNotFoundError:
         try:
-            # Import from the same package
             from . import __version__
 
             return __version__
         except ImportError:
-            # Fallback: read __init__.py file directly
-            try:
-                init_path = os.path.join(os.path.dirname(__file__), "__init__.py")
-                with open(init_path, encoding="utf-8") as f:
-                    for line in f:
-                        if line.strip().startswith("__version__"):
-                            # Extract version string from __version__ = "x.x.x"
-                            return line.split("=")[1].strip().strip('"').strip("'")
-            except (FileNotFoundError, IndexError, AttributeError):
-                pass
-        return "0.0.0"
+            return "0.0.0"

--- a/sdk/rt/speechmatics/rt/_models.py
+++ b/sdk/rt/speechmatics/rt/_models.py
@@ -401,37 +401,34 @@ class ConnectionConfig:
     """
     Configuration for WebSocket connection parameters.
 
-    This class defines all connection-related settings including URL,
-    authentication, timeouts, and advanced features like temporary
-    token generation.
+    This class defines WebSocket-specific settings like ping intervals,
+    message sizes, and connection timeouts.
 
     Attributes:
-        url: WebSocket endpoint URL (e.g., "wss://eu2.rt.speechmatics.com/v2").
-        api_key: Speechmatics API key for authentication.
-        generate_temp_token: Whether to generate temporary tokens for enhanced security.
+        open_timeout: Timeout for establishing WebSocket connection.
+        ping_interval: Interval for WebSocket ping frames.
+        ping_timeout: Timeout waiting for pong response.
+        close_timeout: Timeout for closing WebSocket connection.
+        max_size: Maximum message size in bytes.
+        max_queue: Maximum number of messages in receive queue.
+        read_limit: Maximum number of bytes to read from WebSocket.
+        write_limit: Maximum number of bytes to write to WebSocket.
 
-    Raises:
-        ValueError: If URL format is invalid, API key is empty, timeouts are
-                   not positive, or buffer_size is out of range.
-
-    Examples:
-        Basic configuration:
-            >>> config = ConnectionConfig(
-            ...     url="wss://eu2.rt.speechmatics.com/v2",
-            ...     api_key="your-api-key"
-            ... )
-
-        Configuration with temporary tokens:
-            >>> config = ConnectionConfig(
-            ...     url="wss://eu2.rt.speechmatics.com/v2",
-            ...     api_key="your-main-api-key",
-            ...     generate_temp_token=True,
-            ... )
+    Returns:
+        Websocket connection configuration as a dict while excluding None values.
     """
 
-    url: str
-    api_key: str
-    generate_temp_token: bool = False
+    open_timeout: Optional[float] = None
+    ping_interval: Optional[float] = None
+    ping_timeout: Optional[float] = 60
+    close_timeout: Optional[float] = None
+    max_size: Optional[int] = None
+    max_queue: Optional[int] = None
+    read_limit: Optional[int] = None
+    write_limit: Optional[int] = None
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self, dict_factory=lambda x: {k: v for (k, v) in x if v is not None})
 
 
 @dataclass


### PR DESCRIPTION
- Refactored how JWTs are generated and used in rt sdk
- Added `StaticKeyAuth` (default) and `JWTAuth` classes to differentiate between types of authentication
- `ConnectionConfig` is now used exclusively for configuring the WebSocket connection