### PR TITLE
Change the type for the notification config method

### DIFF
--- a/sdk/batch/speechmatics/batch/_models.py
+++ b/sdk/batch/speechmatics/batch/_models.py
@@ -155,7 +155,7 @@ class NotificationConfig:
     url: str
     contents: Optional[list[NotificationContents]] = None
     auth_headers: Optional[list[str]] = None
-    method: Optional[str] = None
+    method: Optional[NotificationMethod] = None
 
     def to_dict(self) -> dict[str, Any]:
         """Convert to dictionary, excluding None values."""


### PR DESCRIPTION
Expect `NotificationMethod` instead of `str` for the value in the method field of the notification config