### PR TITLE
Add support for custom ssl context in rt sdk

### DIFF
--- a/sdk/rt/speechmatics/rt/_auth.py
+++ b/sdk/rt/speechmatics/rt/_auth.py
@@ -44,9 +44,6 @@ class StaticKeyAuth(AuthBase):
     def __init__(self, api_key: Optional[str] = None):
         self._api_key = api_key or os.environ.get("SPEECHMATICS_API_KEY")
 
-        if not self._api_key:
-            raise ValueError("API key required: provide api_key or set SPEECHMATICS_API_KEY")
-
     async def get_auth_headers(self) -> dict[str, str]:
         return {"Authorization": f"Bearer {self._api_key}"}
 

--- a/sdk/rt/speechmatics/rt/_models.py
+++ b/sdk/rt/speechmatics/rt/_models.py
@@ -465,7 +465,7 @@ class ConnectionConfig:
         max_queue: Maximum number of messages in receive queue.
         read_limit: Maximum number of bytes to read from WebSocket (legacy websockets only).
         write_limit: Maximum number of bytes to write to WebSocket (legacy websockets only).
-        ssl_context: Optional custom SSL context for the WebSocket connection.
+        ssl_context: SSL context for the WebSocket connection.
     Returns:
         Websocket connection configuration as a dict while excluding None values.
     """
@@ -478,7 +478,7 @@ class ConnectionConfig:
     max_queue: Optional[int] = None
     read_limit: Optional[int] = None
     write_limit: Optional[int] = None
-    ssl_context: Optional[ssl.SSLContext] = None
+    ssl_context: ssl.SSLContext = field(default_factory=ssl.create_default_context)
 
     def to_dict(self) -> dict[str, Any]:
         """Convert to dict, excluding ssl field to avoid pickle errors."""

--- a/sdk/rt/speechmatics/rt/_transport.py
+++ b/sdk/rt/speechmatics/rt/_transport.py
@@ -118,15 +118,13 @@ class Transport:
             ws_kwargs: dict = {
                 WS_HEADERS_KEY: ws_headers,
                 **self._conn_config.to_dict(),
+                "ssl": self._conn_config.ssl_context,
             }
 
             # Filter out parameters not supported by new websockets >=13.0
             if not IS_LEGACY_WEBSOCKETS:
                 ws_kwargs.pop("read_limit", None)
                 ws_kwargs.pop("write_limit", None)
-
-            if self._conn_config.ssl_context:
-                ws_kwargs["ssl"] = self._conn_config.ssl_context
 
             self._websocket = await connect(
                 url_with_params,


### PR DESCRIPTION
- Added support for custom ssl context
- Made api key optional to support onprem integrations which don't need one