### PR TITLE
fix to SSL for AsyncClient WebSocket

### DIFF
--- a/sdk/rt/speechmatics/rt/_transport.py
+++ b/sdk/rt/speechmatics/rt/_transport.py
@@ -118,8 +118,11 @@ class Transport:
             ws_kwargs: dict = {
                 WS_HEADERS_KEY: ws_headers,
                 **self._conn_config.to_dict(),
-                "ssl": self._conn_config.ssl_context,
             }
+
+            # SSL
+            if url_with_params.startswith("wss://"):
+                ws_kwargs["ssl"] = self._conn_config.ssl_context
 
             # Filter out parameters not supported by new websockets >=13.0
             if not IS_LEGACY_WEBSOCKETS:


### PR DESCRIPTION
Version 0.5.2 has a new SSL context for WebSocket connections. This prevented non-SSL connections (using `ws://`) from connecting. This update checks if the URL starts with `wss://` before applying the SSL context.