### PR TITLE
Bump Speechmatics RT Dependency to 1.0.0

### DIFF
--- a/sdk/voice/pyproject.toml
+++ b/sdk/voice/pyproject.toml
@@ -11,7 +11,7 @@ authors = [{ name = "Speechmatics", email = "support@speechmatics.com" }]
 license = "MIT"
 requires-python = ">=3.9"
 dependencies = [
-    "speechmatics-rt>=0.5.3",
+    "speechmatics-rt>=1.0.0",
     "pydantic>=2.10.6,<3",
     "numpy>=1.26.4,<3"
 ]

--- a/sdk/voice/pyproject.toml
+++ b/sdk/voice/pyproject.toml
@@ -53,7 +53,6 @@ dev = [
     "pytest-asyncio",
     "pytest-cov",
     "pytest-mock",
-    "aiofiles",
     "build",
 ]
 

--- a/sdk/voice/pyproject.toml
+++ b/sdk/voice/pyproject.toml
@@ -11,7 +11,7 @@ authors = [{ name = "Speechmatics", email = "support@speechmatics.com" }]
 license = "MIT"
 requires-python = ">=3.9"
 dependencies = [
-    "speechmatics-rt>=1.0.0",
+    "speechmatics-rt>=1.0.0, <2",
     "pydantic>=2.10.6,<3",
     "numpy>=1.26.4,<3"
 ]
@@ -53,6 +53,7 @@ dev = [
     "pytest-asyncio",
     "pytest-cov",
     "pytest-mock",
+    "aiofiles",
     "build",
 ]
 

--- a/sdk/voice/pyproject.toml
+++ b/sdk/voice/pyproject.toml
@@ -11,7 +11,7 @@ authors = [{ name = "Speechmatics", email = "support@speechmatics.com" }]
 license = "MIT"
 requires-python = ">=3.9"
 dependencies = [
-    "speechmatics-rt>=1.0.0, <2",
+    "speechmatics-rt>=1.0.0,<2",
     "pydantic>=2.10.6,<3",
     "numpy>=1.26.4,<3"
 ]


### PR DESCRIPTION
This MR updates the Speechmatics RT SDK dependency to `v1.0.0` - which includes functionality to add a timestamp to FEOU messages for improved behaviour.