### PR TITLE
Support Batch Speaker ID

### DIFF
--- a/sdk/batch/speechmatics/batch/__init__.py
+++ b/sdk/batch/speechmatics/batch/__init__.py
@@ -26,6 +26,7 @@ from ._models import NotificationMethod
 from ._models import OperatingPoint
 from ._models import OutputConfig
 from ._models import SentimentAnalysisConfig
+from ._models import SpeakerIdentifier
 from ._models import SummarizationConfig
 from ._models import TopicDetectionConfig
 from ._models import Transcript
@@ -55,6 +56,7 @@ __all__ = [
     "NotificationMethod",
     "OperatingPoint",
     "SentimentAnalysisConfig",
+    "SpeakerIdentifier",
     "StaticKeyAuth",
     "SummarizationConfig",
     "TimeoutError",

--- a/sdk/batch/speechmatics/batch/_models.py
+++ b/sdk/batch/speechmatics/batch/_models.py
@@ -645,6 +645,22 @@ class RecognitionResult:
 
 
 @dataclass
+class SpeakerIdentifier:
+    """A unique speaker detected in the transcript."""
+
+    label: str
+    speaker_identifiers: list[str]
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> SpeakerIdentifier:
+        """Create SpeakerIdentifier from dictionary."""
+        return cls(
+            label=data["label"],
+            speaker_identifiers=data["speaker_identifiers"],
+        )
+
+
+@dataclass
 class Transcript:
     """
     Complete transcript result from a batch transcription job.
@@ -657,6 +673,7 @@ class Transcript:
         job: Job information and metadata.
         metadata: Recognition process metadata.
         results: List of recognition results with timing and alternatives.
+        speakers: List of unique speakers detected in the transcript, each with a label and byte identifiers.
         translations: Optional translations by language code.
         summary: Optional transcript summarization.
         sentiment_analysis: Optional sentiment analysis results.
@@ -670,6 +687,7 @@ class Transcript:
     job: JobInfo
     metadata: RecognitionMetadata
     results: list[RecognitionResult]
+    speakers: Optional[list[SpeakerIdentifier]] = None
     translations: Optional[dict[str, Any]] = None
     summary: Optional[dict[str, Any]] = None
     sentiment_analysis: Optional[dict[str, Any]] = None
@@ -795,11 +813,15 @@ class Transcript:
         results_data = data.get("results", [])
         results = [RecognitionResult.from_dict(result) for result in results_data]
 
+        speakers_data = data.get("speakers")
+        speakers = [SpeakerIdentifier.from_dict(s) for s in speakers_data] if speakers_data else None
+
         return cls(
             format=data["format"],
             job=job_info,
             metadata=metadata,
             results=results,
+            speakers=speakers,
             translations=data.get("translations"),
             summary=data.get("summary"),
             sentiment_analysis=data.get("sentiment_analysis"),


### PR DESCRIPTION
This change exposes the speakers object from our JSON response to users using the batch SDK. 
https://docs.speechmatics.com/api-ref/batch/get-the-transcript-for-a-transcription-job

At the moment this isn't exposed, which means that in order to get speaker IDs, you'd have to handle the raw websocket plumbing yourself. 

This change makes it so that we can access the speakers straight away as a property from the transcription results object. 

