### PR TITLE
Batch support for the next gen model

### DIFF
--- a/sdk/batch/README.md
+++ b/sdk/batch/README.md
@@ -104,7 +104,7 @@ from speechmatics.batch import (
     AsyncClient,
     JobConfig,
     JobType,
-    OperatingPoint,
+    Model,
     TranscriptionConfig,
     TranslationConfig,
     SummarizationConfig

--- a/sdk/batch/speechmatics/batch/_models.py
+++ b/sdk/batch/speechmatics/batch/_models.py
@@ -44,6 +44,8 @@ class OperatingPoint(str, Enum):
 
     ENHANCED = "enhanced"
     STANDARD = "standard"
+    # Not yet available for general use. Support for omni-v1 models is coming soon.
+    OMNI = "omni-v1"
 
 
 class NotificationContents(str, Enum):
@@ -104,16 +106,17 @@ class TranscriptionConfig:
         language_hints: Configuration for the list of languages that are most likely to appear in your audio,
             This improves accuracy by biasing recognition toward the specified languages.
             Use ``language_hints_strict`` to control whether other languages can also be detected.
-            Applicable only for omni-v1 models (not yet available).
+            Applicable only for omni-v1 models. Support for omni-v1 models is coming soon.
         language_hints_strict: Configuration that controls how strictly language hints are applied.
             When ``True``, the transcript will only contain languages specified in ``language_hints``.
             When ``False``, recognition is biased toward the specified languages while still allowing other
             languages to be detected if present.
-            Applicable only for omni-v1 models (not yet available).
+            Applicable only for omni-v1 models. Support for omni-v1 models is coming soon.
     """
 
     language: str = "en"
     operating_point: OperatingPoint = OperatingPoint.ENHANCED
+    model: Optional[OperatingPoint] = None
     output_locale: Optional[str] = None
     diarization: Optional[str] = None
     additional_vocab: Optional[list[dict[str, Any]]] = None
@@ -132,6 +135,8 @@ class TranscriptionConfig:
 
     def to_dict(self) -> dict[str, Any]:
         result: dict[str, Any] = {k: v for k, v in asdict(self).items() if v is not None}
+        if self.model:
+            result["operating_point"] = self.model
         if self.transcript_filtering_config is not None:
             result["transcript_filtering_config"] = self.transcript_filtering_config.to_dict()
         if self.audio_filtering_config is not None:

--- a/sdk/batch/speechmatics/batch/_models.py
+++ b/sdk/batch/speechmatics/batch/_models.py
@@ -101,8 +101,15 @@ class TranscriptionConfig:
             defaults to None.
         audio_filtering_config: Configuration for limiting the transcription of quiet audio.
             Defaults to None.
-        language_hints: Configuration for language hinting, applicable only for the next gen model.
-        language_hints_strict: Configuration for strict language hinting, applicable only for the next gen model.
+        language_hints: Configuration for the list of languages that are most likely to appear in your audio,
+            This improves accuracy by biasing recognition toward the specified languages.
+            Use ``language_hints_strict`` to control whether other languages can also be detected.
+            Applicable only for omni-v1 models (not yet available).
+        language_hints_strict: Configuration that controls how strictly language hints are applied.
+            When ``True``, the transcript will only contain languages specified in ``language_hints``.
+            When ``False``, recognition is biased toward the specified languages while still allowing other
+            languages to be detected if present.
+            Applicable only for omni-v1 models (not yet available).
     """
 
     language: str = "en"

--- a/sdk/batch/speechmatics/batch/_models.py
+++ b/sdk/batch/speechmatics/batch/_models.py
@@ -767,6 +767,7 @@ class Transcript:
         current_speaker = None
         # Each entry is (word, delimiter), where delimiter is looked up from per_language_word_delimiters
         # using the word's language code, falling back to the default word delimiter.
+        # For example, [("hello", " "), ("world", " ")]
         current_group: list[tuple[str, str]] = []
 
         for result in self.results:

--- a/sdk/batch/speechmatics/batch/_models.py
+++ b/sdk/batch/speechmatics/batch/_models.py
@@ -120,12 +120,12 @@ class TranscriptionConfig:
         language_hints: List of languages that are most likely to appear in your audio,
             This improves accuracy by biasing recognition toward the specified languages.
             Use ``language_hints_strict`` to control whether other languages can also be detected.
-            Applicable only for omni-v1 models. Support for omni-v1 models is coming soon.
+            Applicable only for the next-gen models. Support for next-gen models is coming soon.
         language_hints_strict: Controls how strictly language hints are applied.
             When ``True``, the transcript will only contain languages specified in ``language_hints``.
             When ``False``, recognition is biased toward the specified languages while still allowing other
             languages to be detected if present.
-            Applicable only for omni-v1 models. Support for omni-v1 models is coming soon.
+            Applicable only for the next-gen models. Support for the next-gen models is coming soon.
     """
 
     language: str = "en"

--- a/sdk/batch/speechmatics/batch/_models.py
+++ b/sdk/batch/speechmatics/batch/_models.py
@@ -48,8 +48,7 @@ class OperatingPoint(str, Enum):
 
     ENHANCED = "enhanced"
     STANDARD = "standard"
-    # Not yet available for general use. Support for omni-v1 models is coming soon.
-    OMNI = "omni-v1"
+    MELIA_1 = "melia-1"
 
 
 class Model(str, Enum):
@@ -57,6 +56,7 @@ class Model(str, Enum):
 
     ENHANCED = "enhanced"
     STANDARD = "standard"
+    MELIA_1 = "melia-1"
 
 
 class NotificationContents(str, Enum):
@@ -161,10 +161,8 @@ class TranscriptionConfig:
 
     def to_dict(self) -> dict[str, Any]:
         result: dict[str, Any] = {k: v for k, v in asdict(self).items() if v is not None}
-        if self.model:
-            # model is an alias for operating_point for omni-v1 models; they cannot coexist in the request.
-            result["operating_point"] = self.model
-            result.pop("model")
+        if self.model is _UNSET:
+            result.pop("model", None)
         if self.transcript_filtering_config is not None:
             result["transcript_filtering_config"] = self.transcript_filtering_config.to_dict()
         if self.audio_filtering_config is not None:

--- a/sdk/batch/speechmatics/batch/_models.py
+++ b/sdk/batch/speechmatics/batch/_models.py
@@ -765,6 +765,8 @@ class Transcript:
         # Group results by speaker and process
         transcript_parts = []
         current_speaker = None
+        # Each entry is (word, delimiter), where delimiter is looked up from per_language_word_delimiters
+        # using the word's language code, falling back to the default word delimiter.
         current_group: list[tuple[str, str]] = []
 
         for result in self.results:

--- a/sdk/batch/speechmatics/batch/_models.py
+++ b/sdk/batch/speechmatics/batch/_models.py
@@ -744,13 +744,13 @@ class Transcript:
         # Get language pack info for word delimiter
         default_word_delimiter = " "  # Default
         # Applicable only for the next gen models
-        per_lang_word_delimiter: dict = {}
+        per_lang_word_delimiters: dict = {}
         if self.metadata and self.metadata.language_pack_info:
             if "word_delimiter" in self.metadata.language_pack_info:
                 default_word_delimiter = self.metadata.language_pack_info["word_delimiter"]
 
             if "per_language_word_delimiters" in self.metadata.language_pack_info:
-                per_lang_word_delimiter = self.metadata.language_pack_info["per_language_word_delimiters"]
+                per_lang_word_delimiters = self.metadata.language_pack_info["per_language_word_delimiters"]
 
         # Group results by speaker and process
         transcript_parts = []
@@ -765,8 +765,8 @@ class Transcript:
             content = alternative.content
             speaker = alternative.speaker
             word_delimiter = default_word_delimiter
-            if alternative.language and alternative.language in per_lang_word_delimiter:
-                word_delimiter = per_lang_word_delimiter[alternative.language]
+            if alternative.language and alternative.language in per_lang_word_delimiters:
+                word_delimiter = per_lang_word_delimiters[alternative.language]
 
             # Handle speaker changes
             if speaker != current_speaker:

--- a/sdk/batch/speechmatics/batch/_models.py
+++ b/sdk/batch/speechmatics/batch/_models.py
@@ -721,6 +721,9 @@ class Transcript:
         audio_event_summary: Optional audio event statistics.
     """
 
+    _LANG_PACK_WORD_DELIMITER_KEY = "word_delimiter"
+    _LANG_PACK_PER_LANG_DELIMITERS_KEY = "per_language_word_delimiters"
+
     format: str
     job: JobInfo
     metadata: RecognitionMetadata
@@ -753,11 +756,11 @@ class Transcript:
         # Applicable only for the next gen models
         per_lang_word_delimiters: dict = {}
         if self.metadata and self.metadata.language_pack_info:
-            if "word_delimiter" in self.metadata.language_pack_info:
-                default_word_delimiter = self.metadata.language_pack_info["word_delimiter"]
+            if self._LANG_PACK_WORD_DELIMITER_KEY in self.metadata.language_pack_info:
+                default_word_delimiter = self.metadata.language_pack_info[self._LANG_PACK_WORD_DELIMITER_KEY]
 
-            if "per_language_word_delimiters" in self.metadata.language_pack_info:
-                per_lang_word_delimiters = self.metadata.language_pack_info["per_language_word_delimiters"]
+            if self._LANG_PACK_PER_LANG_DELIMITERS_KEY in self.metadata.language_pack_info:
+                per_lang_word_delimiters = self.metadata.language_pack_info[self._LANG_PACK_PER_LANG_DELIMITERS_KEY]
 
         # Group results by speaker and process
         transcript_parts = []

--- a/sdk/batch/speechmatics/batch/_models.py
+++ b/sdk/batch/speechmatics/batch/_models.py
@@ -101,6 +101,8 @@ class TranscriptionConfig:
             defaults to None.
         audio_filtering_config: Configuration for limiting the transcription of quiet audio.
             Defaults to None.
+        language_hints: Configuration for language hinting, applicable only for the next gen model.
+        language_hints_strict: Configuration for strict language hinting, applicable only for the next gen model.
     """
 
     language: str = "en"
@@ -118,6 +120,8 @@ class TranscriptionConfig:
     max_delay_mode: Optional[str] = None
     transcript_filtering_config: Optional[TranscriptFilteringConfig] = None
     audio_filtering_config: Optional[AudioFilteringConfig] = None
+    language_hints: Optional[list[str]] = None
+    language_hints_strict: Optional[bool] = None
 
     def to_dict(self) -> dict[str, Any]:
         result: dict[str, Any] = {k: v for k, v in asdict(self).items() if v is not None}

--- a/sdk/batch/speechmatics/batch/_models.py
+++ b/sdk/batch/speechmatics/batch/_models.py
@@ -136,7 +136,9 @@ class TranscriptionConfig:
     def to_dict(self) -> dict[str, Any]:
         result: dict[str, Any] = {k: v for k, v in asdict(self).items() if v is not None}
         if self.model:
+            # model is an alias for operating_point for omni-v1 models; they cannot coexist in the request.
             result["operating_point"] = self.model
+            result.pop("model")
         if self.transcript_filtering_config is not None:
             result["transcript_filtering_config"] = self.transcript_filtering_config.to_dict()
         if self.audio_filtering_config is not None:

--- a/sdk/batch/speechmatics/batch/_models.py
+++ b/sdk/batch/speechmatics/batch/_models.py
@@ -742,14 +742,20 @@ class Transcript:
             return ""
 
         # Get language pack info for word delimiter
-        word_delimiter = " "  # Default
-        if self.metadata and self.metadata.language_pack_info and "word_delimiter" in self.metadata.language_pack_info:
-            word_delimiter = self.metadata.language_pack_info["word_delimiter"]
+        default_word_delimiter = " "  # Default
+        # Applicable only for the next gen models
+        per_lang_word_delimiter: dict = {}
+        if self.metadata and self.metadata.language_pack_info:
+            if "word_delimiter" in self.metadata.language_pack_info:
+                default_word_delimiter = self.metadata.language_pack_info["word_delimiter"]
+
+            if "per_language_word_delimiters" in self.metadata.language_pack_info:
+                per_lang_word_delimiter = self.metadata.language_pack_info["per_language_word_delimiters"]
 
         # Group results by speaker and process
         transcript_parts = []
         current_speaker = None
-        current_group: list[str] = []
+        current_group: list[tuple[str, str]] = []
 
         for result in self.results:
             if not result.alternatives:
@@ -758,12 +764,15 @@ class Transcript:
             alternative = result.alternatives[0]
             content = alternative.content
             speaker = alternative.speaker
+            word_delimiter = default_word_delimiter
+            if alternative.language and alternative.language in per_lang_word_delimiter:
+                word_delimiter = per_lang_word_delimiter[alternative.language]
 
             # Handle speaker changes
             if speaker != current_speaker:
                 # Process accumulated group for previous speaker
                 if current_group:
-                    text = self._join_content_items(current_group, word_delimiter)
+                    text = self._join_content_items(current_group)
                     if current_speaker:
                         transcript_parts.append(f"SPEAKER {current_speaker}: {text}")  # type: ignore[unreachable]
                     else:
@@ -772,13 +781,13 @@ class Transcript:
 
                 current_speaker = speaker
 
-            # Add content to current group
+            # Add content to current group with its word delimiter
             if content:
-                current_group.append(content)
+                current_group.append((content, word_delimiter))
 
         # Process final group
         if current_group:
-            text = self._join_content_items(current_group, word_delimiter)
+            text = self._join_content_items(current_group)
             if current_speaker:
                 transcript_parts.append(f"SPEAKER {current_speaker}: {text}")
             else:
@@ -786,13 +795,12 @@ class Transcript:
 
         return "\n".join(transcript_parts)
 
-    def _join_content_items(self, content_items: list[str], word_delimiter: str) -> str:
+    def _join_content_items(self, content_items: list[tuple[str, str]]) -> str:
         """
         Join content items with appropriate spacing and punctuation handling.
 
         Args:
-            content_items: List of content strings to join.
-            word_delimiter: Delimiter to use between words.
+            content_items: List of (content, word_delimiter) pairs to join.
 
         Returns:
             Properly formatted text string.
@@ -802,7 +810,7 @@ class Transcript:
 
         result: list[str] = []
 
-        for i, content in enumerate(content_items):
+        for i, (content, word_delimiter) in enumerate(content_items):
             if not content:
                 continue
 

--- a/tests/batch/test_models.py
+++ b/tests/batch/test_models.py
@@ -127,3 +127,64 @@ class TestOutputConfigFromDict:
         data = {"type": "transcription"}
         job_config = JobConfig.from_dict(data)
         assert job_config.output_config is None
+
+
+class TestLanguageHintsToDict:
+    def test_language_hints_serializes_correctly(self):
+        config = TranscriptionConfig(language_hints=["en", "fr"])
+        result = config.to_dict()
+        assert result["language_hints"] == ["en", "fr"]
+
+    def test_language_hints_strict_true_serializes_correctly(self):
+        config = TranscriptionConfig(language_hints=["en"], language_hints_strict=True)
+        result = config.to_dict()
+        assert result["language_hints_strict"] is True
+
+    def test_language_hints_strict_false_included_in_output(self):
+        config = TranscriptionConfig(language_hints=["en"], language_hints_strict=False)
+        result = config.to_dict()
+        assert "language_hints_strict" in result
+        assert result["language_hints_strict"] is False
+
+    def test_language_hints_absent_when_none(self):
+        config = TranscriptionConfig()
+        result = config.to_dict()
+        assert "language_hints" not in result
+        assert "language_hints_strict" not in result
+
+
+class TestLanguageHintsFromDict:
+    def test_language_hints_deserializes_correctly(self):
+        data = {
+            "type": "transcription",
+            "transcription_config": {
+                "language": "en",
+                "language_hints": ["en", "fr"],
+            },
+        }
+        job_config = JobConfig.from_dict(data)
+        assert job_config.transcription_config is not None
+        assert job_config.transcription_config.language_hints == ["en", "fr"]
+
+    def test_language_hints_strict_deserializes_correctly(self):
+        data = {
+            "type": "transcription",
+            "transcription_config": {
+                "language": "en",
+                "language_hints": ["en"],
+                "language_hints_strict": True,
+            },
+        }
+        job_config = JobConfig.from_dict(data)
+        assert job_config.transcription_config is not None
+        assert job_config.transcription_config.language_hints_strict is True
+
+    def test_absent_fields_are_none(self):
+        data = {
+            "type": "transcription",
+            "transcription_config": {"language": "en"},
+        }
+        job_config = JobConfig.from_dict(data)
+        assert job_config.transcription_config is not None
+        assert job_config.transcription_config.language_hints is None
+        assert job_config.transcription_config.language_hints_strict is None

--- a/tests/batch/test_models.py
+++ b/tests/batch/test_models.py
@@ -1,4 +1,4 @@
-from speechmatics.batch._models import JobConfig, TranscriptFilteringConfig, TranscriptionConfig
+from speechmatics.batch._models import JobConfig, OperatingPoint, TranscriptFilteringConfig, TranscriptionConfig
 
 
 class TestTranscriptFilteringConfigToDict:
@@ -127,6 +127,19 @@ class TestOutputConfigFromDict:
         data = {"type": "transcription"}
         job_config = JobConfig.from_dict(data)
         assert job_config.output_config is None
+
+
+class TestModelToDict:
+    def test_model_serializes_as_operating_point(self):
+        config = TranscriptionConfig(model=OperatingPoint.OMNI)
+        result = config.to_dict()
+        assert result["operating_point"] == OperatingPoint.OMNI
+
+    def test_model_absent_leaves_operating_point_unchanged(self):
+        config = TranscriptionConfig(operating_point=OperatingPoint.ENHANCED)
+        result = config.to_dict()
+        assert result["operating_point"] == OperatingPoint.ENHANCED
+        assert "model" not in result
 
 
 class TestLanguageHintsToDict:

--- a/tests/batch/test_models.py
+++ b/tests/batch/test_models.py
@@ -134,6 +134,7 @@ class TestModelToDict:
         config = TranscriptionConfig(model=OperatingPoint.OMNI)
         result = config.to_dict()
         assert result["operating_point"] == OperatingPoint.OMNI
+        assert "model" not in result
 
     def test_model_absent_leaves_operating_point_unchanged(self):
         config = TranscriptionConfig(operating_point=OperatingPoint.ENHANCED)

--- a/tests/batch/test_models.py
+++ b/tests/batch/test_models.py
@@ -134,15 +134,18 @@ class TestLanguageHintsToDict:
         config = TranscriptionConfig(language_hints=["en", "fr"])
         result = config.to_dict()
         assert result["language_hints"] == ["en", "fr"]
+        assert "language_hints_strict" not in result
 
     def test_language_hints_strict_true_serializes_correctly(self):
         config = TranscriptionConfig(language_hints=["en"], language_hints_strict=True)
         result = config.to_dict()
+        assert result["language_hints"] == ["en"]
         assert result["language_hints_strict"] is True
 
-    def test_language_hints_strict_false_included_in_output(self):
+    def test_language_hints_strict_false_serializes_correctly(self):
         config = TranscriptionConfig(language_hints=["en"], language_hints_strict=False)
         result = config.to_dict()
+        assert result["language_hints"] == ["en"]
         assert "language_hints_strict" in result
         assert result["language_hints_strict"] is False
 

--- a/tests/batch/test_models.py
+++ b/tests/batch/test_models.py
@@ -185,6 +185,6 @@ class TestLanguageHintsFromDict:
             "transcription_config": {"language": "en"},
         }
         job_config = JobConfig.from_dict(data)
-        assert job_config.transcription_config is not None
+        assert job_config.transcription_config
         assert job_config.transcription_config.language_hints is None
         assert job_config.transcription_config.language_hints_strict is None

--- a/tests/batch/test_models.py
+++ b/tests/batch/test_models.py
@@ -1,4 +1,8 @@
-from speechmatics.batch._models import JobConfig, OperatingPoint, TranscriptFilteringConfig, TranscriptionConfig
+import json
+
+import pytest
+
+from speechmatics.batch._models import JobConfig, Model, OperatingPoint, TranscriptFilteringConfig, TranscriptionConfig
 
 
 class TestTranscriptFilteringConfigToDict:
@@ -130,17 +134,27 @@ class TestOutputConfigFromDict:
 
 
 class TestModelToDict:
-    def test_model_serializes_as_operating_point(self):
-        config = TranscriptionConfig(model=OperatingPoint.OMNI)
+    def test_model_gets_serialized(self):
+        config = TranscriptionConfig(model=Model.MELIA_1)
         result = config.to_dict()
-        assert result["operating_point"] == OperatingPoint.OMNI
+        assert result["model"] == Model.MELIA_1
+        assert "operating_point" not in result
+
+    def test_operating_point_gets_serialized(self):
+        config = TranscriptionConfig(operating_point=OperatingPoint.STANDARD)
+        result = config.to_dict()
+        assert result["operating_point"] == OperatingPoint.STANDARD
         assert "model" not in result
 
-    def test_model_absent_leaves_operating_point_unchanged(self):
-        config = TranscriptionConfig(operating_point=OperatingPoint.ENHANCED)
+    def test_default_model_is_enhanced(self):
+        config = TranscriptionConfig()
         result = config.to_dict()
-        assert result["operating_point"] == OperatingPoint.ENHANCED
-        assert "model" not in result
+        assert result["model"] == Model.ENHANCED
+        assert "operating_point" not in result
+
+    def test_model_and_operating_point_raises(self):
+        with pytest.raises(ValueError):
+            TranscriptionConfig(model=Model.STANDARD, operating_point=OperatingPoint.STANDARD)
 
 
 class TestLanguageHintsToDict:


### PR DESCRIPTION
This change adds

- Support for the new next-gen model `melia-1.`
- Support for the language hints feature, which is applicable only for the batch next-gen models. The `language_hints` info will be a new field in the transcription_config.  For example:

      {
          "language": "multi",
          "language_hints": ["en", "es"],
          "language_hints_strict": True
      }
- Support new fields in the `metadata.language_pack_info` from `transcript.json-v2` results.