### PR TITLE
fix(rt): don't assume a default audio format

### DIFF
--- a/sdk/rt/speechmatics/rt/_async_client.py
+++ b/sdk/rt/speechmatics/rt/_async_client.py
@@ -12,7 +12,6 @@ from ._exceptions import AudioError
 from ._exceptions import TimeoutError
 from ._exceptions import TranscriptionError
 from ._logging import get_logger
-from ._models import AudioEncoding
 from ._models import AudioEventsConfig
 from ._models import AudioFormat
 from ._models import ClientMessageType
@@ -100,7 +99,9 @@ class AsyncClient(_BaseClient):
         self.on(ServerMessageType.WARNING, self._on_warning)
         self.on(ServerMessageType.AUDIO_ADDED, self._on_audio_added)
 
-        self._audio_format = AudioFormat(encoding=AudioEncoding.PCM_S16LE, sample_rate=44100, chunk_size=4096)
+        # Audio format is set when start_session is called with an explicit format.
+        # Deliberately None until then to avoid silently using incorrect defaults.
+        self._audio_format: Optional[AudioFormat] = None
 
         self._logger.debug("AsyncClient initialized (request_id=%s)", self._session.request_id)
 
@@ -138,10 +139,10 @@ class AsyncClient(_BaseClient):
                 ...     await client.start_session()
                 ...     await client.send_audio(frame)
         """
-        if audio_format is not None:
-            self._audio_format = audio_format
 
-        await self._start_recognition_session(
+        # _start_recognition_session resolves defaults (e.g. AudioFormat() if None),
+        # so we capture the resolved format to keep _audio_format in sync.
+        _, self._audio_format = await self._start_recognition_session(
             transcription_config=transcription_config,
             audio_format=audio_format,
             translation_config=translation_config,
@@ -213,8 +214,13 @@ class AsyncClient(_BaseClient):
         """Number of audio seconds sent to the server.
 
         Raises:
-            ValueError: If the audio format does not have an encoding set.
+            ValueError: If called before start_session has set the audio format,
+                or if the audio format does not have an encoding set.
         """
+        # _audio_format is only set once start_session receives an explicit AudioFormat.
+        # Failing here prevents silently computing with wrong defaults (e.g. 44100Hz).
+        if self._audio_format is None:
+            raise ValueError("audio_seconds_sent is not available before start_session is called with an audio format")
         return self._audio_bytes_sent / (self._audio_format.sample_rate * self._audio_format.bytes_per_sample)
 
     async def transcribe(


### PR DESCRIPTION
## Summary

The RT `AsyncClient` previously initialised `_audio_format` to a hardcoded default (`PCM_S16LE`, 44.1 kHz, 4096-byte chunks). If `audio_seconds_sent` (or anything relying on the format) was consulted before `start_session` supplied a real format, it silently computed against those wrong defaults.

This PR makes the audio format explicit:

- `_audio_format` starts as `None` and is only set once `start_session` resolves an explicit `AudioFormat` (the resolved value is captured back from `_start_recognition_session`).
- `audio_seconds_sent` now raises a `ValueError` if called before `start_session`, instead of returning a value derived from a 44.1 kHz assumption.

## Why

Silently defaulting to 44.1 kHz produced subtly wrong `audio_seconds_sent` values (and therefore timing) for clients that hadn't yet started a session or used a different rate. Failing loudly is safer.

## Notes

- Behavioural change for any consumer that read `audio_seconds_sent`/the format before `start_session` — they now get an explicit error rather than a wrong number.
- Extracted from the `voice/v0.2.9-rc3` pre-release line as one of several focused PRs.

## Test plan

- [ ] RT unit tests pass
- [ ] Confirm `audio_seconds_sent` behaves correctly after `start_session` at 8/16/44.1 kHz
