### PR TITLE
melia-1 model support for RT

### DIFF
--- a/sdk/rt/speechmatics/rt/_models.py
+++ b/sdk/rt/speechmatics/rt/_models.py
@@ -132,7 +132,8 @@ class ServerMessageType(str, Enum):
         AddPartialTranslation: Provides interim translation results that
             may change as more context becomes available.
         SpeakerResult: Provides the speaker identification data.
-        LanguageInfo: Provides information about the detected language(s).
+        LanguageInfo: Sent when a new language is detected, providing the
+            word delimiter and writing direction for that language.
         Info: Informational messages from the server.
         Warning: Warning messages that don't stop transcription.
         Error: Error messages indicating transcription failure.

--- a/sdk/rt/speechmatics/rt/_models.py
+++ b/sdk/rt/speechmatics/rt/_models.py
@@ -40,6 +40,7 @@ class OperatingPoint(str, Enum):
 
     ENHANCED = "enhanced"
     STANDARD = "standard"
+    MELIA_1 = "melia-1"
 
 
 class Model(str, Enum):
@@ -47,6 +48,7 @@ class Model(str, Enum):
 
     ENHANCED = "enhanced"
     STANDARD = "standard"
+    MELIA_1 = "melia-1"
 
 
 @dataclass
@@ -130,6 +132,7 @@ class ServerMessageType(str, Enum):
         AddPartialTranslation: Provides interim translation results that
             may change as more context becomes available.
         SpeakerResult: Provides the speaker identification data.
+        LanguageInfo: Provides information about the detected language(s).
         Info: Informational messages from the server.
         Warning: Warning messages that don't stop transcription.
         Error: Error messages indicating transcription failure.
@@ -160,6 +163,7 @@ class ServerMessageType(str, Enum):
     ADD_TRANSLATION = "AddTranslation"
     ADD_PARTIAL_TRANSLATION = "AddPartialTranslation"
     SPEAKERS_RESULT = "SpeakersResult"
+    LANGUAGE_INFO = "LanguageInfo"
     INFO = "Info"
     WARNING = "Warning"
     ERROR = "Error"


### PR DESCRIPTION
This PR introduces the new Melia-1 model for RT. It also adds a new `LanguageInfo` message from the transcriber, which is sent to the client whenever a new language is detected in the audio. This message includes the word delimiter and writing direction for the detected language.